### PR TITLE
CSS3 enabled

### DIFF
--- a/2017-03-03/index.hta
+++ b/2017-03-03/index.hta
@@ -14,7 +14,7 @@
      SINGLEINSTANCE="no"
      WINDOWSTATE="maximize" />
 
-	<!-- <meta http-equiv="x-ua-compatible" content="ie=9"> -->
+	<meta http-equiv="x-ua-compatible" content="ie=9">
 	<!-- BOLLOCKS! NOW CSS3 COMPATIBLE  -->
 
 <script type = "text/javascript" src="../JSON-js-master/json2.js"></script>

--- a/mylib/css/hta17.css
+++ b/mylib/css/hta17.css
@@ -30,14 +30,14 @@ div#tools  {
 	height:2em;
 	color:#ffffff;
 	background-color: #000000;
-    position: absolute;
+    position: absolute; /* WITH CSS3 ENABLED, THESE 3 LINES ELIMINATE THE NEED FOR AN IE6 HACK */
     left: 0px;
     top: 0px;
 	z-index:55;
 }
 
 * html div#tools  {
-    position: absolute;
+    /* position: absolute; */ /* IE6 HACK */
 }
 /* END OF IE6 HACK */
 
@@ -87,8 +87,8 @@ div#editor div.accordion, div#editor div.accordion h3 {
 }
 div#editor div.accordion > div { /* WE DOUBT IE6 UNDERSTANDS THIS... */
 	position: relative;
-	/* width: 61px; */
-	height: 450px;
+	/* width: 61px; IF WE ENABLE CSS3 USING <meta http-equiv="x-ua-compatible" content="ie=9">, THEN COMMENT OUT THESE TWO LINES */
+	/* height: 450px; */
 }
 td.ninecats {
 	text-decoration: underline;

--- a/mylib/javascript/cool.js
+++ b/mylib/javascript/cool.js
@@ -36,7 +36,7 @@ var cool_formats = {
 	}
 }
 
-var strGreen = "008000";
+var strGreen = "#008000";
 var objPersonal = {}
 
 function patient_data_handling() {
@@ -195,7 +195,9 @@ $.fn.toggleMe = function(){
 	this.parents("div.section").each(function() {
 		var strColor = "red";
 		if($(this).find("div[class~='cool']").length > 0) strColor = strGreen;
+		// alert(strColor);
 		$(this).prev("h3").css("color",strColor);
+		$(this).prev("h3").children("span").last().css("color",strColor);
 	});
 	// RE: THE TARGET div.section AND ITS PRECEDING h3,
 	// THE TEXT WE WANT TO WRITE WILL GO HERE: .prev("h3").children("span").last()


### PR DESCRIPTION
This eliminates the need for the IE6 hack, makes the toolbar fixed and always visible atop, and by changing strGreen from "008000" to "#008000" the .css({}) call is working properly in CSS3 as well.